### PR TITLE
Add checking for models URL from env

### DIFF
--- a/src/OpenAIAuth.py
+++ b/src/OpenAIAuth.py
@@ -254,7 +254,7 @@ class Auth0:
             raise Exception(resp.text)
 
     def get_puid(self) -> str:
-        url = "https://bypass.churchless.tech/models"
+        url = os.getenv("OPENAI_MODELS_URL", "https://bypass.churchless.tech/models")
         headers = {
             "Authorization": "Bearer " + self.access_token,
         }

--- a/src/OpenAIAuth.py
+++ b/src/OpenAIAuth.py
@@ -254,7 +254,7 @@ class Auth0:
             raise Exception(resp.text)
 
     def get_puid(self) -> str:
-        url = os.getenv("OPENAI_MODELS_URL", "https://bypass.churchless.tech/models")
+        url = getenv("OPENAI_MODELS_URL", "https://bypass.churchless.tech/models")
         headers = {
             "Authorization": "Bearer " + self.access_token,
         }


### PR DESCRIPTION
Hi,

Creating a PR to add env variable `OPENAI_MODELS_URL`, which defaults to the current default URL.


Usage (optional):
```
export OPENAI_MODELS_URL="http://localhost.localdomain/models"
```

