### PR TITLE
temporary hotfix to ios getting new preauth

### DIFF
--- a/src/OpenAIAuth.py
+++ b/src/OpenAIAuth.py
@@ -69,6 +69,8 @@ class Auth0:
 
     # temporary fix with loaned preauth cookie.
     def __part_one(self):
+        if getenv("PREAUTH_COOKIE"):
+            return self.__part_two(getenv("PREAUTH_COOKIE"))
         #pandora api https://github.com/pengzhile/pandora/blob/f663d6ecce862e0bd1d8be49893c996ddde521dd/src/pandora/exts/config.py
         preauth_api = getenv("PREAUTH_API_BASE", 'https://ai-{}.fakeopen.com'.format((dt.now() - datetime.timedelta(days=1)).strftime('%Y%m%d'))) 
         url = '{}/auth/preauth'.format(preauth_api)


### PR DESCRIPTION
Hi,

This is a proposal of a temporary hotfix to the new auth problem. This is copied from Pandora, so all credits to them. Also uses their public api on this hotfix, as I can't offer full fix.





```
2023-07-13 更新

咱也不知道OpenAI出于什么心理，在登录时要求验证一个preauth_cookie参数，生成还挺麻烦。
不过不用担心，通过https://ai.fakeopen.com/auth/preauth就能拿到一个可用的preauth_cookie，把它附在登录链接上即可，大概长这样：https://auth0.openai.com/authorize?client_id=...&prompt=login&preauth_cookie=xxx
至于代码，我也已经更新在 Pandora v1.2.7 中了。
```


--

Example of how to get the proper unique preauth cookie:
```
curl -A "ChatGPT/1.2023.187 (iOS 16.5.1; iPad1 4,3; build 1744)" \
     -H "Content-Type: application/json" \
     -d '{
        "bundle_id": "com.openai.chat",
        "device_id": "7D1C7D8A-0707-0707-0707-166B8F380ABC",
        "request_flag": true,
        "device_token": "<ios device token>"
     }' https://ios.chat.openai.com/backend-api/preauth_devicecheck
```
and response cookie: `_preauth_devicecheck` will contain the appropriate preauth cookie.
 I do not know how to generate the device token, someone hopefully has insights on this.

Also sidenote: the device_id in that request can be anything, long as its valid UUID - it's not checked with the device token.